### PR TITLE
fix: force lefthook

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -5,7 +5,6 @@
   "packages": {
     "": {
       "name": "api",
-      "hasInstallScript": true,
       "dependencies": {
         "@hono/node-server": "^1.14.4",
         "bcryptjs": "^3.0.2",

--- a/api/package.json
+++ b/api/package.json
@@ -3,7 +3,6 @@
   "type": "module",
   "private": true,
   "scripts": {
-    "preinstall": "cd .. && npx lefthook install",
     "dev": "tsx watch index.ts",
     "build": "tsc",
     "start": "node dist/index.js",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "version": "0.0.0",
   "private": true,
   "scripts": {
+    "prepare": "npx lefthook install",
     "build:web": "npm run build --prefix web",
     "web": "npm run dev --prefix web",
     "api": "npm run dev --prefix api",

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -7,7 +7,6 @@
     "": {
       "name": "web",
       "version": "0.0.0",
-      "hasInstallScript": true,
       "dependencies": {
         "react": "^19.1.0",
         "react-dom": "^19.1.0",

--- a/web/package.json
+++ b/web/package.json
@@ -1,28 +1,27 @@
 {
-	"name": "web",
-	"private": true,
-	"version": "0.0.0",
-	"type": "module",
-	"scripts": {
-		"preinstall": "cd .. && npx lefthook install",
-		"dev": "vite",
-		"build": "tsc -b && vite build",
-		"preview": "vite preview",
-		"check": "biome check --write ."
-	},
-	"dependencies": {
-		"react": "^19.1.0",
-		"react-dom": "^19.1.0",
-		"react-router": "^7.6.2"
-	},
-	"devDependencies": {
-		"@biomejs/biome": "2.0.0",
-		"@tailwindcss/vite": "^4.1.10",
-		"@types/react": "^19.1.8",
-		"@types/react-dom": "^19.1.6",
-		"@vitejs/plugin-react": "^4.5.2",
-		"tailwindcss": "^4.1.10",
-		"typescript": "~5.8.3",
-		"vite": "^6.3.5"
-	}
+  "name": "web",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc -b && vite build",
+    "preview": "vite preview",
+    "check": "biome check --write ."
+  },
+  "dependencies": {
+    "react": "^19.1.0",
+    "react-dom": "^19.1.0",
+    "react-router": "^7.6.2"
+  },
+  "devDependencies": {
+    "@biomejs/biome": "2.0.0",
+    "@tailwindcss/vite": "^4.1.10",
+    "@types/react": "^19.1.8",
+    "@types/react-dom": "^19.1.6",
+    "@vitejs/plugin-react": "^4.5.2",
+    "tailwindcss": "^4.1.10",
+    "typescript": "~5.8.3",
+    "vite": "^6.3.5"
+  }
 }


### PR DESCRIPTION
reverting 8fd40bc with `prepare` scripts instead on the root package